### PR TITLE
Find method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ $contact = $xero->contacts()->where('Name', 'Bank West')->first();
 
 # Retrieve an individual contact by its GUID
 $contact = $xero->contacts()->find('34xxxx6e-7xx5-2xx4-bxx5-6123xxxxea49');
+
+# Retrieve multiple contact by their GUIDS
+$contacts = $xero->contacts()->find([
+    '34xxxx6e-7xx5-2xx4-bxx5-6123xxxxea49',
+    '364xxxx7f-2xx3-7xx3-gxx7-6726xxxxhe76',
+    ]);
 ```
 
 ### Available relationships

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ $contacts = $xero->contacts()->where('Name', 'Bank West')->get();
 
 # Retrieve an individual contact filtered by name
 $contact = $xero->contacts()->where('Name', 'Bank West')->first();
+
+# Retrieve an individual contact by its GUID
+$contact = $xero->contacts()->find('34xxxx6e-7xx5-2xx4-bxx5-6123xxxxea49');
 ```
 
 ### Available relationships

--- a/src/Apps/PrivateXeroApp.php
+++ b/src/Apps/PrivateXeroApp.php
@@ -100,7 +100,7 @@ class PrivateXeroApp extends PrivateApplication
 
         $model = $this->relationshipToModelMap[$name];
 
-        return new QueryWrapper($this->load($model));
+        return new QueryWrapper($this->load($model), $this);
     }
 
     /**

--- a/src/Wrappers/QueryWrapper.php
+++ b/src/Wrappers/QueryWrapper.php
@@ -96,6 +96,12 @@ class QueryWrapper
         return $this->app->loadByGUID($this->getClass(), $guid);
     }
 
+    /**
+     * Get the Xero class (Contact, Invoice, etc.) that the
+     * wrapped query object is using.
+     *
+     * @return string
+     */
     private function getClass()
     {
         return $this->query->getFrom();

--- a/src/Wrappers/QueryWrapper.php
+++ b/src/Wrappers/QueryWrapper.php
@@ -1,6 +1,7 @@
 <?php
 namespace LangleyFoxall\XeroLaravel\Wrappers;
 
+use LangleyFoxall\XeroLaravel\Apps\PrivateXeroApp;
 use XeroPHP\Remote\Query;
 
 /**
@@ -17,14 +18,22 @@ class QueryWrapper
     private $query;
 
     /**
+     * The Xero app object
+     *
+     * @var Query
+     */
+    private $app;
+
+    /**
      * Builds a QueryWrapper around a Query object
      *
-     * QueryWrapper constructor.
      * @param Query $query
+     * @param PrivateXeroApp $app
      */
-    public function __construct(Query $query)
+    public function __construct(Query $query, PrivateXeroApp $app)
     {
         $this->query = $query;
+        $this->app = $app;
     }
 
     /**
@@ -67,6 +76,29 @@ class QueryWrapper
     public function first()
     {
         return $this->get()->first();
+    }
+
+    /**
+     * Retrieves a model if passed a single GUID.
+     * Retrieves a collection of models if passed an array of GUIDs.
+     *
+     * @param string|array $guid
+     * @return null|\XeroPHP\Remote\Collection|\XeroPHP\Remote\Model
+     * @throws \XeroPHP\Exception
+     * @throws \XeroPHP\Remote\Exception\NotFoundException
+     */
+    public function find($guid)
+    {
+        if (is_array($guid)) {
+            return collect($this->app->loadByGUIDs($this->getClass(), $guid));
+        }
+
+        return $this->app->loadByGUID($this->getClass(), $guid);
+    }
+
+    private function getClass()
+    {
+        return $this->query->getFrom();
     }
 
 }


### PR DESCRIPTION
This PR provides the ability to find Xero models by their GUIDs, similar to the syntax of the Eloquent `find` method.

```php
# Retrieve an individual contact by its GUID
$contact = $xero->contacts()->find('34xxxx6e-7xx5-2xx4-bxx5-6123xxxxea49');

# Retrieve multiple contact by their GUIDS
$contacts = $xero->contacts()->find([
    '34xxxx6e-7xx5-2xx4-bxx5-6123xxxxea49',
    '364xxxx7f-2xx3-7xx3-gxx7-6726xxxxhe76',
    ]);
```
