### PR TITLE
Use directory separator

### DIFF
--- a/src/Apps/PrivateXeroApp.php
+++ b/src/Apps/PrivateXeroApp.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace LangleyFoxall\XeroLaravel\Apps;
 
 use BadMethodCallException;
@@ -12,6 +13,7 @@ use XeroPHP\Application\PrivateApplication;
 
 /**
  * Class PrivateXeroApp
+ *
  * @package LangleyFoxall\XeroLaravel
  */
 class PrivateXeroApp extends PrivateApplication
@@ -48,6 +50,7 @@ class PrivateXeroApp extends PrivateApplication
     public function getAvailableRelationships()
     {
         $relationships = array_keys($this->relationshipToModelMap);
+
         sort($relationships);
 
         return collect($relationships);
@@ -63,9 +66,15 @@ class PrivateXeroApp extends PrivateApplication
      */
     public function populateRelationshipToModelMap($modelSubdirectory, $prefix)
     {
-        $directory = Utils::getProjectRootDirectory();
+        $vendor = Utils::getVendorDirectory();
 
-        $modelsDirectory = $directory.'/vendor/calcinai/xero-php/src/XeroPHP/Models/'.$modelSubdirectory;
+        $dependencyDirectory = Utils::normalizePath(
+            $vendor.'/calcinai/xero-php/src/'
+        );
+
+        $modelsDirectory = Utils::normalizePath(
+            $dependencyDirectory.'/XeroPHP/Models/'.$modelSubdirectory
+        );
 
         $di = new RecursiveDirectoryIterator($modelsDirectory);
         foreach (new RecursiveIteratorIterator($di) as $filename => $file) {
@@ -73,8 +82,19 @@ class PrivateXeroApp extends PrivateApplication
                 continue;
             }
 
-            $relationship = Str::camel($prefix.Str::plural(str_replace([$modelsDirectory, '.php', '/'], ['', '', ''], $filename)));
-            $model = str_replace([$directory.'/vendor/calcinai/xero-php/src/', '/', '.php'], ['', '\\', ''], $filename);
+            $relationship = Str::camel(
+                $prefix.Str::plural(
+                    str_replace(
+                        [$modelsDirectory, '.php', DIRECTORY_SEPARATOR], '',
+                        $filename
+                    )
+                )
+            );
+
+            $model = str_replace(
+                [$dependencyDirectory, DIRECTORY_SEPARATOR, '.php'], ['', '\\'],
+                $filename
+            );
 
             $this->relationshipToModelMap[$relationship] = $model;
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace LangleyFoxall\XeroLaravel;
 
 use Exception;
@@ -19,18 +20,38 @@ abstract class Utils
 
         do {
             $directory = dirname($directory);
-            $composer = $directory.'/composer.json';
-            $vendor = $directory.'/vendor/';
+            $composer = self::normalizePath($directory.'/composer.json');
+            $vendor = self::normalizePath($directory.'/vendor/');
 
-            if (file_exists($composer) && file_exists($vendor)) {
+            if (file_exists($composer) && is_dir($vendor)) {
                 $root = $directory;
             }
-        } while (is_null($root) && $directory != '/');
+        } while (is_null($root) && $directory != DIRECTORY_SEPARATOR);
 
         if (!is_null($root)) {
             return $root;
         }
 
         throw new Exception('Unable to determine project root directory.');
+    }
+
+    /**
+     * @return string
+     * @throws Exception
+     */
+    public static function getVendorDirectory()
+    {
+        return self::normalizePath(
+            self::getProjectRootDirectory().'/vendor'
+        );
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    public static function normalizePath(string $path)
+    {
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
 }


### PR DESCRIPTION
This PR adds a utility function `normalizePath` that replaces UNIX styled path separators with PHP's `DIRECTORY_SEPARATOR` constant to allow for multi-OS compatibility.

Closes #12.

---

🦆 typo in commit message