### PR TITLE
Bump Laravel Framework to include 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php":">=7.1",
-        "laravel/framework": "^5.1||^6.0||^7.0",
-        "calcinai/xero-php": "^2.0"
+        "laravel/framework": "^5.1||^6.0||^7.0||^8.0",
+        "calcinai/xero-php": "^2.2.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Also requires Cacinai/xero-php to be updated to support GuzzleHTTP ^6.0||^7.0 and also PSR7 in the same repository. I have issued a separate PR for that to happen at that repository. This can be committed once that PR is accepted and rolled in.