### PR TITLE
Fix for php 7.4

### DIFF
--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -130,7 +130,7 @@ class OAuth2
      * @param string|null $grantType
      * @return AccessTokenInterface
      */
-    public function refreshAccessToken(AccessTokenInterface $accessToken, string? $grantType = null)
+    public function refreshAccessToken(AccessTokenInterface $accessToken, $grantType = null)
     {
         $body = [
             'refresh_token' => $accessToken->getRefreshToken()


### PR DESCRIPTION
This error restricts oauth2 authentication

Fix for Issue #53 syntax error, unexpected '?', expecting variable (T_VARIABLE) 

